### PR TITLE
Update bashrc for undercloud upgrade

### DIFF
--- a/rc-files/bashrc
+++ b/rc-files/bashrc
@@ -332,8 +332,6 @@ function plan-download {
 
 function undercloud-upgrade {
     set -x
-    sudo systemctl stop openstack-*
-    sudo systemctl stop neutron-*
     sudo yum -y update python-tripleoclient
     openstack undercloud upgrade
     set +x


### PR DESCRIPTION
You don't need to stop services anymore, it's handled by Ansible if needed.
I found the info on stackoverflow.